### PR TITLE
Incorporate Fluentbit tests

### DIFF
--- a/testbed/testbed/child_process_collector.go
+++ b/testbed/testbed/child_process_collector.go
@@ -123,6 +123,13 @@ func (cp *childProcessCollector) PrepareConfig(t *testing.T, configStr string) (
 			}
 			cp.agentExePath = wrapperPath
 			cp.additionalEnv["ROTEL_PATH"] = os.Getenv("ROTEL_PATH")
+		} else if strings.HasPrefix(sp[1], "Fluentbit") {
+			wrapperPath := os.Getenv("FLUENTBIT_OTEL_WRAPPER")
+			if wrapperPath == "" {
+				panic("Can not find FLUENTBIT_OTEL_WRAPPER")
+			}
+			cp.agentExePath = wrapperPath
+			cp.additionalEnv["FLUENTBIT_PATH"] = os.Getenv("FLUENTBIT_PATH")
 		}
 	}
 

--- a/testbed/tests/rotel_test.go
+++ b/testbed/tests/rotel_test.go
@@ -51,6 +51,24 @@ func TestRotelLog10kDPS(t *testing.T) {
 				ExpectedMaxRAM: 120,
 			},
 		},
+		{
+			name:     "Fluentbit-OTLP",
+			sender:   testbed.NewOTLPLogsDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t)),
+			receiver: testbed.NewOTLPDataReceiver(testutil.GetAvailablePort(t)),
+			resourceSpec: testbed.ResourceSpec{
+				ExpectedMaxCPU: 30,
+				ExpectedMaxRAM: 120,
+			},
+		},
+		{
+			name:     "Fluentbit-OTLP-HTTP",
+			sender:   testbed.NewOTLPHTTPLogsDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t)),
+			receiver: testbed.NewOTLPHTTPDataReceiver(testutil.GetAvailablePort(t)),
+			resourceSpec: testbed.ResourceSpec{
+				ExpectedMaxCPU: 30,
+				ExpectedMaxRAM: 120,
+			},
+		},
 	}
 
 	processors := []ProcessorNameAndConfigBody{
@@ -115,6 +133,24 @@ func TestRotelMetric10kDPS(t *testing.T) {
 		},
 		{
 			name:     "RotelOTLP-HTTP",
+			sender:   testbed.NewOTLPHTTPMetricDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t)),
+			receiver: testbed.NewOTLPHTTPDataReceiver(testutil.GetAvailablePort(t)),
+			resourceSpec: testbed.ResourceSpec{
+				ExpectedMaxCPU: 60,
+				ExpectedMaxRAM: 100,
+			},
+		},
+		{
+			name:     "FluentbitOTLP",
+			sender:   testbed.NewOTLPMetricDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t)),
+			receiver: testbed.NewOTLPDataReceiver(testutil.GetAvailablePort(t)),
+			resourceSpec: testbed.ResourceSpec{
+				ExpectedMaxCPU: 60,
+				ExpectedMaxRAM: 105,
+			},
+		},
+		{
+			name:     "FluentbitOTLP-HTTP",
 			sender:   testbed.NewOTLPHTTPMetricDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t)),
 			receiver: testbed.NewOTLPHTTPDataReceiver(testutil.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
@@ -222,6 +258,42 @@ func TestRotelTrace10kSPS(t *testing.T) {
 				ExpectedMaxRAM: 100,
 			},
 		},
+		{
+			"Fluentbit-OTLP-gRPC",
+			testbed.NewOTLPTraceDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t)),
+			testbed.NewOTLPDataReceiver(testutil.GetAvailablePort(t)),
+			testbed.ResourceSpec{
+				ExpectedMaxCPU: 20,
+				ExpectedMaxRAM: 100,
+			},
+		},
+		{
+			"Fluentbit-OTLP-gRPC-gzip",
+			testbed.NewOTLPTraceDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t)),
+			testbed.NewOTLPDataReceiver(testutil.GetAvailablePort(t)).WithCompression("gzip"),
+			testbed.ResourceSpec{
+				ExpectedMaxCPU: 30,
+				ExpectedMaxRAM: 100,
+			},
+		},
+		{
+			"Fluentbit-OTLP-HTTP",
+			testbed.NewOTLPHTTPTraceDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t), ""),
+			testbed.NewOTLPHTTPDataReceiver(testutil.GetAvailablePort(t)),
+			testbed.ResourceSpec{
+				ExpectedMaxCPU: 20,
+				ExpectedMaxRAM: 100,
+			},
+		},
+		{
+			"Fluentbit-OTLP-HTTP-gzip",
+			testbed.NewOTLPHTTPTraceDataSender(testbed.DefaultHost, testutil.GetAvailablePort(t), "gzip"),
+			testbed.NewOTLPHTTPDataReceiver(testutil.GetAvailablePort(t)).WithCompression("gzip"),
+			testbed.ResourceSpec{
+				ExpectedMaxCPU: 25,
+				ExpectedMaxRAM: 100,
+			},
+		},
 	}
 
 	processors := []ProcessorNameAndConfigBody{
@@ -250,7 +322,7 @@ func TestRotelTrace10kSPS(t *testing.T) {
 }
 
 func TestRotelTrace1kSPSWithAttrs(t *testing.T) {
-	for _, prefix := range []string{"", "Rotel-"} {
+	for _, prefix := range []string{"", "Rotel-", "Fluentbit-"} {
 		Scenario1kSPSWithAttrs(t, prefix, []string{}, []TestCase{
 			// No attributes.
 			{


### PR DESCRIPTION
This incorporates the Fluentbit tests into the test matrix. To test this locally (on `fluent-tests` branch):

1. `make genoteltestbedcol`
2. `make oteltestbedcol`
3. Set the following:
   - `ROTEL_OTEL_WRAPPER`: path to rotel otel wrapper
   - `ROTEL_PATH`: path to otel
   - `FLUENTBIT_OTEL_WRAPPER`: path to fluentbit otel wrapper
   - `FLUENTBIT_PATH`: path to fluentbit
4. `cd testbed && TEST_ARGS="-run ^TestRotel" ./runtests.sh`

It should output results to the commandline.

Completes: STR-3439